### PR TITLE
Block library installation on Python 2

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [wheel]
-universal = 1
+universal = 0
 
 [flake8]
 ignore = D203,E501,F405,E731,FI10,FI12,FI15,FI16,FI17,FI18,FI50,FI51,FI52,FI53,FI54,FI55,FI56,FI57,E741

--- a/setup.py
+++ b/setup.py
@@ -83,6 +83,7 @@ setup(
         'fluent_compiler>=0.2',
         'Django>=1.11',
     ],
+    python_requires='>=3.5',
     license="MIT",
     zip_safe=False,
     keywords='django-ftl',


### PR DESCRIPTION
Version 0.13 of `django-ftl` is currently installable on Python 2 via `pip`.

This pull requests follows the instructions documented at https://packaging.python.org/guides/dropping-older-python-versions/ to:
 * Declare the minimal supported python version to forbid installation by pip on python versions that do not match (by adding `python_requires` in `setup.py`;
 * Declare the built wheel as being python 3 only - which blocks installation of the wheel file in Python 2 environments;