### PR TITLE
Add missing test for plural sectors in TestDocs

### DIFF
--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -17,3 +17,19 @@ class TestDocs(TestBase):
             "events-greeting", {"username": "boaty mcboatface"}
         )
         self.assertEqual(greeting, "Hello, \u2068boaty mcboatface\u2069")
+
+        zero_events_info = ftl_bundle.format(
+            "events-new-events-info", {"count": 0}
+        )
+        self.assertEqual(zero_events_info, "There have been no new events since your last event.")
+        one_event_info = ftl_bundle.format(
+            "events-new-events-info", {"count": 1}
+        )
+        self.assertEqual(one_event_info, "There has been one new event since your last visit.")
+        many_event_info = ftl_bundle.format(
+            "events-new-events-info", {"count": 2}
+        )
+        self.assertEqual(
+            many_event_info,
+            "There have been \u20682\u2069 new events since your last visit."
+        )


### PR DESCRIPTION
This PR adds tests for `events-new-events-info` which tests for plural selectors.